### PR TITLE
fix: topups and restore hash160 identity keys

### DIFF
--- a/dash-sdk-java/src/test/java/org/dashj/platform/sdk/IdentityTest.java
+++ b/dash-sdk-java/src/test/java/org/dashj/platform/sdk/IdentityTest.java
@@ -1,6 +1,7 @@
 package org.dashj.platform.sdk;
 
 import org.bitcoinj.core.Base58;
+import org.bitcoinj.core.Utils;
 import org.dashj.platform.sdk.base.Result;
 import org.junit.Test;
 
@@ -55,6 +56,14 @@ public class IdentityTest extends SdkBaseTest {
     public void identityBalanceTest() throws Exception {
         Identifier id = new Identifier(Base58.decode(testIdentifier));
         Result<Long, String> result2 = dashsdk.platformMobileFetchIdentityFetchIdentityBalanceWithSdk(sdk, id);
+        result2.unwrap();
+    }
+
+
+    @Test
+    public void identityFromHash160Test() throws Exception {
+        byte [] id = Utils.HEX.decode("a9579df520c44c8d8773887bc5c9fbec579b962a");
+        Result<Identity, String> result2 = dashsdk.platformMobileFetchIdentityFetchIdentityWithKeyhashSdk(mainNetSdk, id);
         result2.unwrap();
     }
 }

--- a/dash-sdk-java/src/test/java/org/dashj/platform/sdk/SdkBaseTest.java
+++ b/dash-sdk-java/src/test/java/org/dashj/platform/sdk/SdkBaseTest.java
@@ -26,6 +26,9 @@ public class SdkBaseTest extends BaseTest {
     @AfterClass
     public static void tearDown() {
         dashsdk.platformMobileSdkDestroyDashSdk(sdk);
+        if (mainNetSdk != null) {
+            dashsdk.platformMobileSdkDestroyDashSdk(mainNetSdk);
+        }
         // SWIGTYPE_p_DashSdk does not own the pointer
         // assertEquals(sdk.getCPointer(), 0);
     }

--- a/dash-sdk-java/src/test/java/org/dashj/platform/sdk/SdkBaseTest.java
+++ b/dash-sdk-java/src/test/java/org/dashj/platform/sdk/SdkBaseTest.java
@@ -5,19 +5,22 @@ import org.junit.BeforeClass;
 
 import java.math.BigInteger;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class SdkBaseTest extends BaseTest {
 
     static SWIGTYPE_p_DashSdk sdk;
+    static SWIGTYPE_p_DashSdk mainNetSdk;
 
     @BeforeClass
     public static void startUp() {
         sdk = dashsdk.platformMobileSdkCreateDashSdk(BigInteger.ZERO, BigInteger.ZERO, true);
         assertNotNull(sdk);
         assertNotEquals(sdk.getCPointer(), 0L);
+        mainNetSdk = dashsdk.platformMobileSdkCreateDashSdk(BigInteger.ZERO, BigInteger.ZERO, false);
+        assertNotNull(mainNetSdk);
+        assertNotEquals(mainNetSdk.getCPointer(), 0L);
     }
 
     @AfterClass

--- a/dpp/src/main/java/org/dashj/platform/dashpay/BlockchainIdentity.kt
+++ b/dpp/src/main/java/org/dashj/platform/dashpay/BlockchainIdentity.kt
@@ -566,7 +566,7 @@ class BlockchainIdentity {
             try {
                 topUpWithISLock(topupAssetLockTransaction, keyParameter)
             } catch (e: Exception) {
-
+                log.info("topup error:", e)
                 if (e is InvalidInstantAssetLockProofException ||
                     e.message?.contains("Instant lock proof signature is invalid or wasn't created recently. Pleases try chain asset lock proof instead.") == true ||
                     e.message?.contains(Regex("Asset Lock proof core chain height \\d+ is higher than the current consensus core height \\d+")) == true) {

--- a/dpp/src/main/java/org/dashj/platform/dpp/identity/ChainAssetLockProof.kt
+++ b/dpp/src/main/java/org/dashj/platform/dpp/identity/ChainAssetLockProof.kt
@@ -25,7 +25,7 @@ class ChainAssetLockProof(
             coreChainLockedHeight,
             TransactionOutPoint(
                 params,
-                outPoint.sliceArray(0 until OUTPOINT_HASH_SIZE).reversedArray().plus(
+                outPoint.sliceArray(0 until OUTPOINT_HASH_SIZE).plus(
                     outPoint.sliceArray(OUTPOINT_HASH_SIZE until OUTPOINT_SIZE)
                 ),
                 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a fallback non-unique key-hash identity lookup to improve identity retrieval when unique matches are absent.

- Bug Fixes
  - Fixed transaction outpoint hash handling for asset lock proofs, improving validation reliability.

- Refactor
  - Improved runtime/SDK interaction and added diagnostic logging for identity fetch and top-up error flows.

- Tests
  - Added tests for key-hash identity retrieval and mainnet SDK initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->