### PR TITLE
[CI] Test rust-dashcore PR #579

### DIFF
--- a/dash-sdk-android/src/main/rust/Cargo.toml
+++ b/dash-sdk-android/src/main/rust/Cargo.toml
@@ -22,7 +22,7 @@ dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = [
     "rand",
     "signer",
     "serde",
-], default-features = false, tag = "v0.39.6" }
+], default-features = false, rev = "8cbae416458565faac21d3452fbc6d80b324f6d3" }
 drive = { path = "../../../../../platform/packages/rs-drive", default-features = false, features = [
     "verify",
     "serde",

--- a/dash-sdk-bindings/Cargo.toml
+++ b/dash-sdk-bindings/Cargo.toml
@@ -27,7 +27,7 @@ dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = [
     "rand",
     "signer",
     "serde",
-], default-features = false, tag = "v0.39.6" }
+], default-features = false, rev = "8cbae416458565faac21d3452fbc6d80b324f6d3" }
 [build-dependencies]
 cbindgen = "0.26.0"
 ferment-sys = { git = "https://github.com/dashpay/ferment", tag = "v0.2.3", package = "ferment-sys", features = ["cbindgen_only"] }

--- a/platform-mobile/Cargo.toml
+++ b/platform-mobile/Cargo.toml
@@ -45,10 +45,10 @@ dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = [
     "rand",
     "signer",
     "serde",
-], default-features = false, tag = "v0.39.6" }
-dashcore_hashes = { git = "https://github.com/dashpay/rust-dashcore" }
+], default-features = false, rev = "8cbae416458565faac21d3452fbc6d80b324f6d3" }
+dashcore_hashes = { git = "https://github.com/dashpay/rust-dashcore", rev = "8cbae416458565faac21d3452fbc6d80b324f6d3" }
 # dashcore-rpc is only needed for core rpc; TODO remove once we have correct core rpc impl
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.39.6" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "8cbae416458565faac21d3452fbc6d80b324f6d3" }
 rand = "0.8.5"
 base64 = "0.13"
 tonic = { version = "0.11", features = [


### PR DESCRIPTION
🔧 **Automated integration test** by @dashinfraclaw

Testing [dashpay/rust-dashcore#579](https://github.com/dashpay/rust-dashcore/pull/579) (chore(ffi): move header files generation to the target directory) against this repo.

**Changes:** Updated `dashcore`, `dashcore_hashes`, and `dashcore-rpc` dependencies across 3 Cargo.toml files to use rev `8cbae416458565faac21d3452fbc6d80b324f6d3` (was tag v0.39.6).

This PR will be closed after CI results are recorded.