### PR TITLE
[CI] Test rust-dashcore PR #579

### DIFF
--- a/dash-sdk-android/src/main/rust/Cargo.toml
+++ b/dash-sdk-android/src/main/rust/Cargo.toml
@@ -42,7 +42,7 @@ tower-layer = { git = "https://github.com/QuantumExplorer/tower", branch = "fix/
 tower = { git = "https://github.com/QuantumExplorer/tower", branch = "fix/indexMap2OnV0413" }
 # this is required until this PR is merged
 rs-x11-hash = { git = "https://github.com/hashengineering/rs-x11-hash", branch = "feat/add-android-support" }
-elliptic-curve-tools = { git = "https://github.com/mikelodder7/elliptic-curve-tools", rev = "5789c0491252d5af8add829348af9dd6ac09d8f6" }
+elliptic-curve-tools = { git = "https://github.com/mikelodder7/elliptic-curve-tools", rev = "8cbae416458565faac21d3452fbc6d80b324f6d3" }
 
 [lib]
 crate-type = ["staticlib"]

--- a/dash-sdk-bindings/Cargo.toml
+++ b/dash-sdk-bindings/Cargo.toml
@@ -36,7 +36,7 @@ toml = "0.8.8"
 
 [patch.crates-io]
 rs-x11-hash = { git = "https://github.com/hashengineering/rs-x11-hash", branch = "feat/add-android-support" }
-elliptic-curve-tools = { git = "https://github.com/mikelodder7/elliptic-curve-tools", rev = "5789c0491252d5af8add829348af9dd6ac09d8f6" }
+elliptic-curve-tools = { git = "https://github.com/mikelodder7/elliptic-curve-tools", rev = "8cbae416458565faac21d3452fbc6d80b324f6d3" }
 
 [lib]
 crate-type = ["staticlib"]

--- a/platform-mobile/Cargo.toml
+++ b/platform-mobile/Cargo.toml
@@ -48,7 +48,7 @@ dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = [
 ], default-features = false, tag = "v0.39.6" }
 dashcore_hashes = { git = "https://github.com/dashpay/rust-dashcore" }
 # dashcore-rpc is only needed for core rpc; TODO remove once we have correct core rpc impl
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.39.6" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "8cbae416458565faac21d3452fbc6d80b324f6d3" }
 rand = "0.8.5"
 base64 = "0.13"
 tonic = { version = "0.11", features = [


### PR DESCRIPTION
Automated integration test for [dashpay/rust-dashcore#579](https://github.com/dashpay/rust-dashcore/pull/579).

This PR updates the rust-dashcore dependency to commit `8cbae416458565faac21d3452fbc6d80b324f6d3` to verify downstream compatibility.

**This PR will be automatically closed after CI results are collected.**

---
_Triggered by @ktechmidas via `@dashinfraclaw fulltest`_