### PR TITLE
chore: update rust-dashcore dependency to store TransactionContext in TransactionRecord

### DIFF
--- a/dash-sdk-android/src/main/rust/Cargo.toml
+++ b/dash-sdk-android/src/main/rust/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 [dependencies]
 dash-sdk = { path = "../../../../../platform/packages/rs-sdk" }
 #dash-sdk = { git = "https://github.com/dashpay/platform.git", branch="v1.0-dev" }
-ferment-macro = { git = "https://github.com/dashpay/ferment", branch = "feat/opaque-default", package = "ferment-macro" }
-ferment-interfaces = { git = "https://github.com/dashpay/ferment", branch = "feat/opaque-default", package = "ferment-interfaces" }
+ferment-macro = { git = "https://github.com/dashpay/ferment", rev = "5114330ae564858803d656efba84bb4adacb2a2e", package = "ferment-macro" }
+ferment-interfaces = { git = "https://github.com/dashpay/ferment", rev = "5114330ae564858803d656efba84bb4adacb2a2e", package = "ferment-interfaces" }
 
 platform-mobile = { path = "../../../../platform-mobile"}
 
@@ -22,26 +22,26 @@ dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = [
     "rand",
     "signer",
     "serde",
-], default-features = false, tag = "v0.39.6" }
+], default-features = false, rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
 drive = { path = "../../../../../platform/packages/rs-drive", default-features = false, features = [
     "verify",
     "serde",
 ] }
 drive-proof-verifier = { path = "../../../../../platform/packages/rs-drive-proof-verifier"}
-ferment = { git = "https://github.com/dashpay/ferment", tag = "v0.2.3", package = "ferment" }
+ferment = { git = "https://github.com/dashpay/ferment", rev = "5114330ae564858803d656efba84bb4adacb2a2e", package = "ferment" }
 
 [build-dependencies]
 cbindgen = "0.26.0"
-# ferment = { git = "https://github.com/dashpay/ferment", tag = "v0.2.3", package = "ferment" }
-ferment-sys = { git = "https://github.com/dashpay/ferment", tag = "v0.2.3", package = "ferment-sys", features = ["cbindgen_only"] }
-#ferment-sys = { git = "https://github.com/dashpay/ferment", tag = "v0.2.3", package = "ferment-sys" }
+# ferment = { git = "https://github.com/dashpay/ferment", rev = "5114330ae564858803d656efba84bb4adacb2a2e", package = "ferment" }
+ferment-sys = { git = "https://github.com/dashpay/ferment", rev = "5114330ae564858803d656efba84bb4adacb2a2e", package = "ferment-sys", features = ["cbindgen_only"] }
+#ferment-sys = { git = "https://github.com/dashpay/ferment", rev = "5114330ae564858803d656efba84bb4adacb2a2e", package = "ferment-sys" }
 
 [patch.crates-io]
-tower-service = { git = "https://github.com/QuantumExplorer/tower", branch = "fix/indexMap2OnV0413" }
-tower-layer = { git = "https://github.com/QuantumExplorer/tower", branch = "fix/indexMap2OnV0413" }
-tower = { git = "https://github.com/QuantumExplorer/tower", branch = "fix/indexMap2OnV0413" }
+tower-service = { git = "https://github.com/QuantumExplorer/tower", rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
+tower-layer = { git = "https://github.com/QuantumExplorer/tower", rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
+tower = { git = "https://github.com/QuantumExplorer/tower", rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
 # this is required until this PR is merged
-rs-x11-hash = { git = "https://github.com/hashengineering/rs-x11-hash", branch = "feat/add-android-support" }
+rs-x11-hash = { git = "https://github.com/hashengineering/rs-x11-hash", rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
 elliptic-curve-tools = { git = "https://github.com/mikelodder7/elliptic-curve-tools", rev = "5789c0491252d5af8add829348af9dd6ac09d8f6" }
 
 [lib]

--- a/dash-sdk-bindings/Cargo.toml
+++ b/dash-sdk-bindings/Cargo.toml
@@ -4,8 +4,8 @@ version = "2.0.4"
 edition = "2021"
 
 [dependencies]
-ferment = { git = "https://github.com/dashpay/ferment", tag = "v0.2.3", package = "ferment" }
-ferment-macro = { git = "https://github.com/dashpay/ferment", tag = "v0.2.3", package = "ferment-macro" }
+ferment = { git = "https://github.com/dashpay/ferment", rev = "5114330ae564858803d656efba84bb4adacb2a2e", package = "ferment" }
+ferment-macro = { git = "https://github.com/dashpay/ferment", rev = "5114330ae564858803d656efba84bb4adacb2a2e", package = "ferment-macro" }
 platform-mobile = { path = "../platform-mobile"}
 # dependencies required by ferment
 platform-value = { path = "../../platform/packages/rs-platform-value" }
@@ -27,15 +27,15 @@ dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = [
     "rand",
     "signer",
     "serde",
-], default-features = false, tag = "v0.39.6" }
+], default-features = false, rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
 [build-dependencies]
 cbindgen = "0.26.0"
-ferment-sys = { git = "https://github.com/dashpay/ferment", tag = "v0.2.3", package = "ferment-sys", features = ["cbindgen_only"] }
-#ferment-sys = { git = "https://github.com/dashpay/ferment", tag = "v0.2.3", package = "ferment-sys"}
+ferment-sys = { git = "https://github.com/dashpay/ferment", rev = "5114330ae564858803d656efba84bb4adacb2a2e", package = "ferment-sys", features = ["cbindgen_only"] }
+#ferment-sys = { git = "https://github.com/dashpay/ferment", rev = "5114330ae564858803d656efba84bb4adacb2a2e", package = "ferment-sys"}
 toml = "0.8.8"
 
 [patch.crates-io]
-rs-x11-hash = { git = "https://github.com/hashengineering/rs-x11-hash", branch = "feat/add-android-support" }
+rs-x11-hash = { git = "https://github.com/hashengineering/rs-x11-hash", rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
 elliptic-curve-tools = { git = "https://github.com/mikelodder7/elliptic-curve-tools", rev = "5789c0491252d5af8add829348af9dd6ac09d8f6" }
 
 [lib]

--- a/platform-mobile/Cargo.toml
+++ b/platform-mobile/Cargo.toml
@@ -4,8 +4,8 @@ version = "2.0.4"
 edition = "2021"
 
 [dependencies]
-ferment = { git = "https://github.com/dashpay/ferment", tag = "v0.2.3", package = "ferment" }
-ferment-macro = { git = "https://github.com/dashpay/ferment", tag = "v0.2.3", package = "ferment-macro" }
+ferment = { git = "https://github.com/dashpay/ferment", rev = "5114330ae564858803d656efba84bb4adacb2a2e", package = "ferment" }
+ferment-macro = { git = "https://github.com/dashpay/ferment", rev = "5114330ae564858803d656efba84bb4adacb2a2e", package = "ferment-macro" }
 
 platform-value = { path = "../../platform/packages/rs-platform-value" }
 data-contracts = { path = "../../platform/packages/data-contracts" }
@@ -45,10 +45,10 @@ dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = [
     "rand",
     "signer",
     "serde",
-], default-features = false, tag = "v0.39.6" }
-dashcore_hashes = { git = "https://github.com/dashpay/rust-dashcore" }
+], default-features = false, rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
+dashcore_hashes = { git = "https://github.com/dashpay/rust-dashcore", rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
 # dashcore-rpc is only needed for core rpc; TODO remove once we have correct core rpc impl
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.39.6" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
 rand = "0.8.5"
 base64 = "0.13"
 tonic = { version = "0.11", features = [


### PR DESCRIPTION
Automated integration test for [dashpay/rust-dashcore#582](https://github.com/dashpay/rust-dashcore/pull/582).

**What:** Updated all `dashcore`/`dashcore-rpc` git dependencies to PR HEAD commit (`5114330ae564858803d656efba84bb4adacb2a2e`).

**Why:** Validates that the changes in rust-dashcore PR #582 (`refactor: store TransactionContext in TransactionRecord`) compile and pass CI against this repository.

**Changes:** Dependency pointer update only — no functional code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `dashcore-rpc` dependency from a tagged release to a specific commit reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->