### PR TITLE
chore: update rust-dashcore dependency to store TransactionContext in TransactionRecord

### DIFF
--- a/dash-sdk-android/src/main/rust/Cargo.toml
+++ b/dash-sdk-android/src/main/rust/Cargo.toml
@@ -22,7 +22,7 @@ dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = [
     "rand",
     "signer",
     "serde",
-], default-features = false, tag = "v0.39.6" }
+], default-features = false, rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
 drive = { path = "../../../../../platform/packages/rs-drive", default-features = false, features = [
     "verify",
     "serde",

--- a/dash-sdk-bindings/Cargo.toml
+++ b/dash-sdk-bindings/Cargo.toml
@@ -27,7 +27,7 @@ dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = [
     "rand",
     "signer",
     "serde",
-], default-features = false, tag = "v0.39.6" }
+], default-features = false, rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
 [build-dependencies]
 cbindgen = "0.26.0"
 ferment-sys = { git = "https://github.com/dashpay/ferment", tag = "v0.2.3", package = "ferment-sys", features = ["cbindgen_only"] }

--- a/platform-mobile/Cargo.toml
+++ b/platform-mobile/Cargo.toml
@@ -45,10 +45,10 @@ dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = [
     "rand",
     "signer",
     "serde",
-], default-features = false, tag = "v0.39.6" }
-dashcore_hashes = { git = "https://github.com/dashpay/rust-dashcore" }
+], default-features = false, rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
+dashcore_hashes = { git = "https://github.com/dashpay/rust-dashcore", rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
 # dashcore-rpc is only needed for core rpc; TODO remove once we have correct core rpc impl
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.39.6" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "5114330ae564858803d656efba84bb4adacb2a2e" }
 rand = "0.8.5"
 base64 = "0.13"
 tonic = { version = "0.11", features = [


### PR DESCRIPTION
Automated integration test for [dashpay/rust-dashcore#582](https://github.com/dashpay/rust-dashcore/pull/582).

**What:** Updated all `dashcore`/`dashcore-rpc` git dependencies to PR HEAD commit (`5114330ae564858803d656efba84bb4adacb2a2e`).

**Why:** Validates that the changes in rust-dashcore PR #582 (`refactor: store TransactionContext in TransactionRecord`) compile and pass CI against this repository.

**Changes:** Dependency pointer update only — no functional code changes.